### PR TITLE
Feature/ensure correct file extension

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,6 +2,7 @@ import * as vscode from "vscode";
 import { analyze } from "./core";
 import { generateMermaidDiagram } from "./impl/genMermaid";
 import { getWebviewContent } from "./utils/getWebviewContent";
+import { isSupportedFileExtension } from "./utils/isSupportedFileExtension";
 
 // Todo: Improve the correctness of files traversal, its currently not dynamic
 
@@ -9,8 +10,19 @@ export function activate(context: vscode.ExtensionContext) {
   const disposable = vscode.commands.registerCommand("hooked.analyze", () => {
     const editor = vscode.window.activeTextEditor;
 
+    if (!editor) {
+      vscode.window.showInformationMessage("No active editor found.");
+      return;
+    }
+
     const hooks = analyze(editor?.document.uri.path || "");
     const baseFileName = editor?.document.fileName.split("/").pop();
+
+    if (!isSupportedFileExtension(baseFileName)) {
+      vscode.window.showInformationMessage("Expected a Javascript or Typescript extension");
+      return;
+    }
+    
 
     if (!hooks) {
       vscode.window.showInformationMessage("No hooks found!");

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -19,10 +19,9 @@ export function activate(context: vscode.ExtensionContext) {
     const baseFileName = editor?.document.fileName.split("/").pop();
 
     if (!isSupportedFileExtension(baseFileName)) {
-      vscode.window.showInformationMessage("Expected a Javascript or Typescript extension");
+      vscode.window.showInformationMessage("Expected a file with .js, .ts, or .tsx extension.");
       return;
-    }
-    
+    } 
 
     if (!hooks) {
       vscode.window.showInformationMessage("No hooks found!");

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -18,6 +18,10 @@ export function activate(context: vscode.ExtensionContext) {
     const hooks = analyze(editor?.document.uri.path || "");
     const baseFileName = editor?.document.fileName.split("/").pop();
 
+    if (baseFileName === undefined) {
+      return;
+    }
+
     if (!isSupportedFileExtension(baseFileName)) {
       vscode.window.showInformationMessage("Expected a file with .js, .ts, or .tsx extension.");
       return;

--- a/src/utils/assertHookPath.ts
+++ b/src/utils/assertHookPath.ts
@@ -20,3 +20,4 @@ export function assertHookPath(filePath: string) {
 
   return hookPath;
 }
+

--- a/src/utils/isSupportedFileExtension.ts
+++ b/src/utils/isSupportedFileExtension.ts
@@ -1,9 +1,5 @@
-export function isSupportedFileExtension(path: string | undefined) {
+export function isSupportedFileExtension(path: string) {
   const validExtensions = ['.js', '.ts', '.tsx'];
-
-  if (path === undefined) {
-    return false;
-  }
 
   const fileExtension = path.slice(path.lastIndexOf('.'));
 

--- a/src/utils/isSupportedFileExtension.ts
+++ b/src/utils/isSupportedFileExtension.ts
@@ -1,0 +1,11 @@
+export function isSupportedFileExtension(path: string | undefined) {
+  const validExtensions = ['.js', '.ts', '.tsx'];
+
+  if (path === undefined) {
+    return false;
+  }
+
+  const fileExtension = path.slice(path.lastIndexOf('.'));
+
+  return validExtensions.includes(fileExtension);
+}


### PR DESCRIPTION
This PR adds the following changes:

- Ensures we show an appropriate error if the user has not selected an editor window when running the extension.
- Ensures we check the file extension of the current file before performing expensive I/O operations, like visiting imports and analysing the AST.