### PR TITLE
feat: Enhance file extension support and improve user feedback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+./dist

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "hooked",
   "displayName": "Hooked - React Hooks Analyzer",
   "description": "",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "icon": "./assets/hooked.png",
   "engines": {
     "vscode": "^1.90.0"

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -38,3 +38,8 @@ export const DEFAULT_ACCEPTED_HOOKS = [
  * Directories that are not considered screens
  */
 export const NON_SCREEN_DIRS = ["hooks", "components"];
+
+/**
+ * File extensions that are supported by the analyzer
+ */
+export const SUPPORTED_EXTENSIONS = [".js", ".ts", ".tsx", ".jsx"];

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,6 +3,7 @@ import { analyze } from "./core";
 import { generateMermaidDiagram } from "./impl/genMermaid";
 import { getWebviewContent } from "./utils/getWebviewContent";
 import { isSupportedFileExtension } from "./utils/isSupportedFileExtension";
+import { SUPPORTED_EXTENSIONS } from "./config/constants";
 
 // Todo: Improve the correctness of files traversal, its currently not dynamic
 
@@ -23,9 +24,13 @@ export function activate(context: vscode.ExtensionContext) {
     }
 
     if (!isSupportedFileExtension(baseFileName)) {
-      vscode.window.showInformationMessage("Expected a file with .js, .ts, or .tsx extension.");
+      const expectedExtensions = SUPPORTED_EXTENSIONS.join(", ");
+
+      vscode.window.showInformationMessage(
+        `This file type is not supported. Please open a file with one of these extensions: ${expectedExtensions}`
+      );
       return;
-    } 
+    }
 
     if (!hooks) {
       vscode.window.showInformationMessage("No hooks found!");

--- a/src/utils/assertHookPath.ts
+++ b/src/utils/assertHookPath.ts
@@ -16,8 +16,11 @@ export function assertHookPath(filePath: string) {
     hookPath += ".ts";
   } else if (fs.existsSync(`${hookPath}.tsx`)) {
     hookPath += ".tsx";
+  } else if (fs.existsSync(`${hookPath}.jsx`)) {
+    hookPath += ".jsx";
+  } else if (fs.existsSync(`${hookPath}.js`)) {
+    hookPath += ".js";
   }
 
   return hookPath;
 }
-

--- a/src/utils/isSupportedFileExtension.ts
+++ b/src/utils/isSupportedFileExtension.ts
@@ -1,7 +1,12 @@
-export function isSupportedFileExtension(path: string) {
-  const validExtensions = [".js", ".ts", ".tsx", ".jsx"];
+import { SUPPORTED_EXTENSIONS } from "../config/constants";
 
+/**
+ * Checks if a file has a supported extension (.js, .ts, .tsx, .jsx)
+ * @param path - The file path or name to check
+ * @returns boolean - True if the file extension is supported, false otherwise
+ */
+export function isSupportedFileExtension(path: string) {
   const fileExtension = path.slice(path.lastIndexOf("."));
 
-  return validExtensions.includes(fileExtension);
+  return SUPPORTED_EXTENSIONS.includes(fileExtension);
 }


### PR DESCRIPTION
- Added support for `.jsx` file extension in the file path assertion and validation utilities.
- Updated the error message to list all supported file extensions dynamically.
- Included `.dist` directory in `.gitignore` to prevent build artifacts from being tracked.