### PR TITLE
fix: correct relative path resolution in visitImports

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -16,7 +16,6 @@ export function activate(context: vscode.ExtensionContext) {
       return;
     }
 
-    const hooks = analyze(editor?.document.uri.path || "");
     const baseFileName = editor?.document.fileName.split("/").pop();
 
     if (baseFileName === undefined) {
@@ -31,6 +30,8 @@ export function activate(context: vscode.ExtensionContext) {
       );
       return;
     }
+
+    const hooks = analyze(editor?.document.uri.path || "");
 
     if (!hooks) {
       vscode.window.showInformationMessage("No hooks found!");

--- a/src/impl/visitImports.ts
+++ b/src/impl/visitImports.ts
@@ -80,7 +80,10 @@ export function visitImports(
     let hookPath = "";
 
     if (isRelative) {
-      hookPath = assertHookPath(path.resolve(filePath, dependency.importPath));
+      const currentDir = path.dirname(filePath);
+      hookPath = assertHookPath(
+        path.resolve(currentDir, dependency.importPath)
+      );
     } else {
       hookPath = assertHookPath(
         // It would be better if we could get a configuration to indicate the path


### PR DESCRIPTION
This PR includes
- Fixes #5 
- Improves relative path resolution
- Prevents `analyze()` from being called if file path not supported. 

<img width="271" alt="Screenshot 2025-01-03 at 18 21 52" src="https://github.com/user-attachments/assets/60a2ba89-0f8a-49e2-aec1-bf45d2603d4c" />
